### PR TITLE
Show Linux Kernel Version

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -126,6 +126,8 @@ commands:
       name: Build image provisioning date and time
 
     - lsb_release -a
+    - command: uname -sr
+      name: Linux Kernel Version
 
     # - command: COLUMNS=200 dpkg --list
     #   name:    Local Packages (via APT)


### PR DESCRIPTION
This is an important information, especially because of the gap between Docker and OpenVZ environments:

* docker: `Linux 3.13.0-40-generic`
* openvz: `Linux 2.6.32-042stab094.7`