### PR TITLE
Align the way to show Operating System Details

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -125,9 +125,10 @@ commands:
     - command: date
       name: Build image provisioning date and time
 
-    - lsb_release -a
-    - command: uname -sr
-      name: Linux Kernel Version
+    - command: lsb_release -a
+      name: Operating System Details
+    - command: uname -r
+      name: Linux Version
 
     # - command: COLUMNS=200 dpkg --list
     #   name:    Local Packages (via APT)
@@ -137,8 +138,10 @@ commands:
     - command: date
       name: Build image provisioning date and time
 
-    - uname -a
     - command: sw_vers
+      name: Operating System Details
+    - command: uname -r
+      name: Darwin Version
 
     # - command: brew ls --versions
     #   name:    Local Packages (via Homebrew)


### PR DESCRIPTION
@BanzaiMan this is a follow-up of #6 and 67cf125ea0098ef9aa70baea67cd4732e7eb31ff.

With this change, the operating system details are similarly listed in Mac and Linux systems.